### PR TITLE
redo exports to include makeHtmlSanitizer

### DIFF
--- a/sanitizer.js
+++ b/sanitizer.js
@@ -890,8 +890,6 @@ html4 .ELEMENTS = {
   'var': 0
 };
 
-exports.escape = html.escapeAttrib;
-exports.makeSaxParser = html.makeSaxParser;
-exports.normalizeRCData = html.normalizeRCData;
-exports.sanitize = html_sanitize;
-exports.unescapeEntities = html.unescapeEntities;
+html.escape = html.escapeAttrib;
+html.sanitize = html_sanitize;
+module.exports = html;


### PR DESCRIPTION
I wanted access to html.makeHtmlSanitizer, but it wasn't exported.  I reworked the exports to provide that.
