### PR TITLE
Add var to Sanitizer declaration to stop global variable leak

### DIFF
--- a/sanitizer.js
+++ b/sanitizer.js
@@ -1067,7 +1067,7 @@ if (typeof window !== 'undefined') {
     window['html_sanitize'] = html_sanitize;
 }
 
-Sanitizer = {};
+var Sanitizer = {};
 
 // Ensure backwards compatibility
 Sanitizer.escapeAttrib = html.escapeAttrib;


### PR DESCRIPTION
I had Mocha complaining "Error: global leak detected: Sanitizer" - but adding a "var" fixes this.
