### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
     "mail" : "bensmawfield@googlemail.com",
     "url"  : "http://github.com/theSmaw/Caja-HTML-Sanitizer/issues"
   },
-  "licenses" : [{
-    "type": "Apache",
-    "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-  }],
+  "license"     : "Apache-2.0",
   "main"        : "./sanitizer.js",
   "repository" : {
     "type" : "git",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/